### PR TITLE
Fix WiFi connection status not being replicated when connected network is removed via `removeNetwork`.

### DIFF
--- a/web/src/stores/connection.store.ts
+++ b/web/src/stores/connection.store.ts
@@ -64,7 +64,15 @@ useNuiEvent<WifiNetwork>('addNetwork', (data: WifiNetwork) => {
 useNuiEvent<string>('removeNetwork', (ssid: string) => {
   const connection = useConnection()
 
+  const oldConnections = connection.networks
   connection.networks = connection.networks.filter((network) => network.ssid !== ssid)
+
+  // Check to see if the networks array was changed via the filter operation.
+  // If it was, let the network event bus be aware of this change.
+  if(oldConnections.length !== connection.networks.length) {
+    const networkBus = useEventBus('network')
+    networkBus.emit('updated')
+  }
 })
 
 useNuiEvent<string>('connect', (ssid: string) => {


### PR DESCRIPTION
This PR fixes an issue with the network event bus not knowing about the currently connected network being removed. This should allow custom apps to have a fully accurate representation of the network state in their app state without any de-sync issues.

I would've added it to the previous PR but I didn't realize the issue til after the merge.