### PR TITLE
Make sure to keep the laptop id if exists

### DIFF
--- a/bridge/ox_inventory/imports/server.lua
+++ b/bridge/ox_inventory/imports/server.lua
@@ -9,11 +9,13 @@ local ox_inventory = exports.ox_inventory
 local registeredStashes = {}
 
 ox_inventory:registerHook('createItem', function(payload)
-    local id = utils.uuid()
+    local metadata = payload.metadata or {}
 
-    return {
-        id = id,
-    }
+    -- Set metadata to include the recipe name
+    if not metadata or not metadata.id then
+        metadata = { id = utils.uuid() }
+    end
+    return metadata
 end, {
     print = config.debug,
     itemFilter = {


### PR DESCRIPTION
Hello 👋 

While testing things locally, I've noticed that if I gave my laptop with some USB inside it, the other player wouldn't see the item inside the storage.

Looking into the `createItem` it seems that we were assigning a new uuid each time we got the item, but we also trigger that hook when giving the item to someone.

This code makes sure that it will only set a new id IF there's no id set in metadata. 

Not sure if this helps or if you are happy with the changes. Please let me know 😄 