### PR TITLE
fix: desktop persistence & positioning

### DIFF
--- a/web/src/lib/stores/appsStore.svelte.ts
+++ b/web/src/lib/stores/appsStore.svelte.ts
@@ -70,6 +70,32 @@ class AppsStore {
     return { x, y }
   }
 
+  fixOutOfBoundsApps() {
+    if (this.desktopRows <= 0 || this.desktopApps.length === 0) return
+
+    const occupied = new Set<string>(
+      this.desktopApps
+        .filter(a => a.y < this.desktopRows)
+        .map(a => `${a.x},${a.y}`)
+    )
+
+    let changed = false
+
+    for (const app of this.desktopApps) {
+      if (app.y >= this.desktopRows) {
+        const { x, y } = this.nextFreeCell(occupied)
+        occupied.add(`${x},${y}`)
+        app.x = x
+        app.y = y
+        changed = true
+      }
+    }
+
+    if (changed) {
+      this.saveDesktopApps()
+    }
+  }
+
   addDesktopIcon(id: string) {
     if (!this.apps.find((app) => app.id === id)) return
     if (this.desktopApps.find((app) => app.appId === id)) return
@@ -374,5 +400,7 @@ onNuiEvent<DesktopApp[]>('desktopApps', (payload) => {
 
   if (payload.length === 0) {
     appsStore.populateDefaultDesktopApps()
+  } else {
+    appsStore.fixOutOfBoundsApps()
   }
 })

--- a/web/src/lib/views/Desktop.svelte
+++ b/web/src/lib/views/Desktop.svelte
@@ -115,7 +115,7 @@
       if (cell) {
         const { col, row } = cell
 
-        const occupant = appsStore.filteredDesktopApps.find(
+        const occupant = appsStore.desktopApps.find(
           (item) => item !== dragItem && item.x === col && item.y === row
         )
 
@@ -152,10 +152,23 @@
     cols = Math.floor(desktopRef.clientWidth / CELL_W) || 16
   }
 
+  function computeRows() {
+    if (!desktopRef || desktopRef.clientHeight === 0) return
+    const rows = Math.floor(desktopRef.clientHeight / (CELL_H + MARGIN))
+    if (rows > 0) {
+      appsStore.desktopRows = rows
+      appsStore.fixOutOfBoundsApps()
+    }
+  }
+
   onMount(() => {
     computeCols()
+    computeRows()
 
-    const observer = new ResizeObserver(() => computeCols())
+    const observer = new ResizeObserver(() => {
+      computeCols()
+      computeRows()
+    })
     if (desktopRef) observer.observe(desktopRef)
 
     return () => observer.disconnect()


### PR DESCRIPTION
Calculate visible rows to prevent icons landing under the taskbar and ensure occupancy checks include hidden apps to avoid duplicates.